### PR TITLE
Feature/add progress entry endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,22 @@
         </dependency>
 
         <!-- MapStruct -->
+<!--        <dependency>-->
+<!--            <groupId>org.mapstruct</groupId>-->
+<!--            <artifactId>mapstruct</artifactId>-->
+<!--            <version>${mapstruct.version}</version>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
-            <version>${mapstruct.version}</version>
+            <version>1.5.5.Final</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>1.5.5.Final</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Lombok -->

--- a/src/main/java/com/wellu/usermanagement/controller/ProgressEntryController.java
+++ b/src/main/java/com/wellu/usermanagement/controller/ProgressEntryController.java
@@ -1,0 +1,46 @@
+package com.wellu.usermanagement.controller;
+
+import com.wellu.usermanagement.dto.request.ProgressEntryCreateRequest;
+import com.wellu.usermanagement.dto.response.ProgressEntryResponse;
+import com.wellu.usermanagement.security.CustomUserPrincipal;
+import com.wellu.usermanagement.service.ProgressEntryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/progress-entries")
+public class ProgressEntryController {
+
+    private ProgressEntryService progressEntryService;
+
+    public ProgressEntryController(ProgressEntryService progressEntryService) {
+        this.progressEntryService = progressEntryService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ProgressEntryResponse> create(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @RequestBody ProgressEntryCreateRequest request
+    ) {
+        return ResponseEntity.ok(progressEntryService.create(principal.getUserId(), request));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ProgressEntryResponse>> getAll(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        return ResponseEntity.ok(progressEntryService.getAll(principal.getUserId()));
+    }
+
+//    @DeleteMapping("/{id}")
+//    public ResponseEntity<Void> delete(
+//            @AuthenticationPrincipal CustomUserPrincipal principal,
+//            @PathVariable UUID id
+//    ) {
+//        progressEntryService.delete(principal.getUserId(), id);
+//        return ResponseEntity.noContent().build();
+//    }
+}

--- a/src/main/java/com/wellu/usermanagement/controller/ProgressEntryController.java
+++ b/src/main/java/com/wellu/usermanagement/controller/ProgressEntryController.java
@@ -1,6 +1,7 @@
 package com.wellu.usermanagement.controller;
 
 import com.wellu.usermanagement.dto.request.ProgressEntryCreateRequest;
+import com.wellu.usermanagement.dto.request.ProgressEntryUpdateRequest;
 import com.wellu.usermanagement.dto.response.ProgressEntryResponse;
 import com.wellu.usermanagement.security.CustomUserPrincipal;
 import com.wellu.usermanagement.service.ProgressEntryService;
@@ -9,6 +10,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/progress-entries")
@@ -35,12 +37,23 @@ public class ProgressEntryController {
         return ResponseEntity.ok(progressEntryService.getAll(principal.getUserId()));
     }
 
-//    @DeleteMapping("/{id}")
-//    public ResponseEntity<Void> delete(
-//            @AuthenticationPrincipal CustomUserPrincipal principal,
-//            @PathVariable UUID id
-//    ) {
-//        progressEntryService.delete(principal.getUserId(), id);
-//        return ResponseEntity.noContent().build();
-//    }
+    @PutMapping("/{id}")
+    public ResponseEntity<ProgressEntryResponse> update(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PathVariable UUID id,
+            @RequestBody ProgressEntryUpdateRequest request
+    ) {
+        return ResponseEntity.ok(
+                progressEntryService.update(principal.getUserId(), id, request)
+        );
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PathVariable UUID id
+    ) {
+        progressEntryService.delete(principal.getUserId(), id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/wellu/usermanagement/dto/request/ProgressEntryCreateRequest.java
+++ b/src/main/java/com/wellu/usermanagement/dto/request/ProgressEntryCreateRequest.java
@@ -1,0 +1,9 @@
+package com.wellu.usermanagement.dto.request;
+
+public record ProgressEntryCreateRequest(
+         Double weight,
+         Double caloriesBurnt,
+         Integer workoutCompleted,
+         String notes
+) {
+}

--- a/src/main/java/com/wellu/usermanagement/dto/request/ProgressEntryUpdateRequest.java
+++ b/src/main/java/com/wellu/usermanagement/dto/request/ProgressEntryUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.wellu.usermanagement.dto.request;
+
+public record UpdateProgressEntryRequest() {
+}

--- a/src/main/java/com/wellu/usermanagement/dto/request/ProgressEntryUpdateRequest.java
+++ b/src/main/java/com/wellu/usermanagement/dto/request/ProgressEntryUpdateRequest.java
@@ -1,4 +1,9 @@
 package com.wellu.usermanagement.dto.request;
 
-public record UpdateProgressEntryRequest() {
+public record ProgressEntryUpdateRequest(
+        Double weight,
+        Double caloriesBurnt,
+        Integer workoutCompleted,
+        String notes
+) {
 }

--- a/src/main/java/com/wellu/usermanagement/dto/response/ProgressEntryResponse.java
+++ b/src/main/java/com/wellu/usermanagement/dto/response/ProgressEntryResponse.java
@@ -1,0 +1,15 @@
+package com.wellu.usermanagement.dto.response;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record ProgressEntryResponse(
+
+        UUID id,
+         Double weight,
+         Double caloriesBurnt,
+         Integer workoutCompleted,
+         String notes,
+         Instant recordedAt
+) {
+}

--- a/src/main/java/com/wellu/usermanagement/entity/ProgressEntry.java
+++ b/src/main/java/com/wellu/usermanagement/entity/ProgressEntry.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.Instant;
-import java.time.LocalDate;
 import java.util.UUID;
 
 @Entity
@@ -19,7 +18,7 @@ import java.util.UUID;
 @Table(name="progress_entries")
 public class ProgressEntry {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue
     @Column(name="id")
     private UUID id;
 

--- a/src/main/java/com/wellu/usermanagement/entity/UserProfile.java
+++ b/src/main/java/com/wellu/usermanagement/entity/UserProfile.java
@@ -59,4 +59,6 @@ public class UserProfile {
     public double calculateBMI(){
         return weight / (height * height);
     }
+
+
 }

--- a/src/main/java/com/wellu/usermanagement/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/wellu/usermanagement/exception/GlobalExceptionHandler.java
@@ -117,6 +117,15 @@ public class GlobalExceptionHandler {
                 .body(new ApiError(400,"Database constraint violation"));
     }
 
+    @ExceptionHandler(ProgressEntryNotFound.class)
+    public ResponseEntity<ApiError> handleAllExceptions(ProgressEntryNotFound ex) {
+
+        return new ResponseEntity<>(
+                new ApiError(404, "Progress entry not found."),
+                HttpStatus.BAD_REQUEST
+        );
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiError> handleAllExceptions(Exception ex) {
 

--- a/src/main/java/com/wellu/usermanagement/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/wellu/usermanagement/exception/GlobalExceptionHandler.java
@@ -117,8 +117,8 @@ public class GlobalExceptionHandler {
                 .body(new ApiError(400,"Database constraint violation"));
     }
 
-    @ExceptionHandler(ProgressEntryNotFound.class)
-    public ResponseEntity<ApiError> handleAllExceptions(ProgressEntryNotFound ex) {
+    @ExceptionHandler(ProgressEntryException.class)
+    public ResponseEntity<ApiError> handleAllExceptions(ProgressEntryException ex) {
 
         return new ResponseEntity<>(
                 new ApiError(404, "Progress entry not found."),

--- a/src/main/java/com/wellu/usermanagement/exception/ProgressEntryException.java
+++ b/src/main/java/com/wellu/usermanagement/exception/ProgressEntryException.java
@@ -1,7 +1,7 @@
 package com.wellu.usermanagement.exception;
 
-public class ProgressEntryNotFoundException extends RuntimeException {
-    public ProgressEntryNotFoundException(String message) {
+public class ProgressEntryException extends RuntimeException {
+    public ProgressEntryException(String message) {
         super(message);
     }
 }

--- a/src/main/java/com/wellu/usermanagement/exception/ProgressEntryException.java
+++ b/src/main/java/com/wellu/usermanagement/exception/ProgressEntryException.java
@@ -1,0 +1,7 @@
+package com.wellu.usermanagement.exception;
+
+public class ProgressEntryNotFoundException extends RuntimeException {
+    public ProgressEntryNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/wellu/usermanagement/mapper/ProgressEntryMapper.java
+++ b/src/main/java/com/wellu/usermanagement/mapper/ProgressEntryMapper.java
@@ -1,0 +1,18 @@
+package com.wellu.usermanagement.mapper;
+
+import com.wellu.usermanagement.dto.request.ProgressEntryCreateRequest;
+import com.wellu.usermanagement.dto.response.ProgressEntryResponse;
+import com.wellu.usermanagement.entity.ProgressEntry;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.springframework.stereotype.Component;
+
+@Mapper(componentModel = "spring")
+public interface ProgressEntryMapper {
+    ProgressEntryResponse toResponse(ProgressEntry entity);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "recordedAt", ignore = true)
+    @Mapping(target = "userProfile", ignore = true)
+    ProgressEntry toEntity(ProgressEntryCreateRequest request);
+}

--- a/src/main/java/com/wellu/usermanagement/mapper/ProgressEntryMapper.java
+++ b/src/main/java/com/wellu/usermanagement/mapper/ProgressEntryMapper.java
@@ -1,10 +1,10 @@
 package com.wellu.usermanagement.mapper;
 
 import com.wellu.usermanagement.dto.request.ProgressEntryCreateRequest;
+import com.wellu.usermanagement.dto.request.ProgressEntryUpdateRequest;
 import com.wellu.usermanagement.dto.response.ProgressEntryResponse;
 import com.wellu.usermanagement.entity.ProgressEntry;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+import org.mapstruct.*;
 import org.springframework.stereotype.Component;
 
 @Mapper(componentModel = "spring")
@@ -15,4 +15,8 @@ public interface ProgressEntryMapper {
     @Mapping(target = "recordedAt", ignore = true)
     @Mapping(target = "userProfile", ignore = true)
     ProgressEntry toEntity(ProgressEntryCreateRequest request);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateFromDto(ProgressEntryUpdateRequest request,
+                       @MappingTarget ProgressEntry entry);
 }

--- a/src/main/java/com/wellu/usermanagement/repository/MedicationRepository.java
+++ b/src/main/java/com/wellu/usermanagement/repository/MedicationRepository.java
@@ -1,6 +1,5 @@
 package com.wellu.usermanagement.repository;
 
-import com.wellu.usermanagement.entity.Injury;
 import com.wellu.usermanagement.entity.Medication;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/wellu/usermanagement/repository/ProgressEntryRepository.java
+++ b/src/main/java/com/wellu/usermanagement/repository/ProgressEntryRepository.java
@@ -1,0 +1,12 @@
+package com.wellu.usermanagement.repository;
+
+import com.wellu.usermanagement.entity.ProgressEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+public interface ProgressEntryRepository extends JpaRepository<ProgressEntry, UUID> {
+    List<ProgressEntry> findByUserProfile_UserId(UUID userId);
+}

--- a/src/main/java/com/wellu/usermanagement/service/ProgressEntryService.java
+++ b/src/main/java/com/wellu/usermanagement/service/ProgressEntryService.java
@@ -1,0 +1,76 @@
+package com.wellu.usermanagement.service;
+
+import com.wellu.usermanagement.dto.request.ProgressEntryCreateRequest;
+import com.wellu.usermanagement.dto.response.ProgressEntryResponse;
+import com.wellu.usermanagement.entity.ProgressEntry;
+import com.wellu.usermanagement.entity.UserProfile;
+import com.wellu.usermanagement.exception.ProfileNotFoundException;
+import com.wellu.usermanagement.mapper.ProgressEntryMapper;
+import com.wellu.usermanagement.repository.ProgressEntryRepository;
+import com.wellu.usermanagement.repository.UserProfileRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class ProgressEntryService {
+    UserProfileRepository userProfileRepository;
+    ProgressEntryRepository progressEntryRepository;
+    ProgressEntryMapper progressEntryMapper;
+
+    public ProgressEntryService(UserProfileRepository userProfileRepository, ProgressEntryRepository progressEntryRepository,ProgressEntryMapper progressEntryMapper) {
+        this.userProfileRepository = userProfileRepository;
+        this.progressEntryRepository = progressEntryRepository;
+        this.progressEntryMapper = progressEntryMapper;
+    }
+
+    public ProgressEntryResponse create(UUID userId, ProgressEntryCreateRequest request) {
+        if (request.weight() == null || request.weight() <= 0) {
+            throw new IllegalArgumentException("Weight must be greater than 0");
+        }
+
+        if (request.caloriesBurnt() != null && request.caloriesBurnt() < 0) {
+            throw new IllegalArgumentException("Calories burnt cannot be negative");
+        }
+
+        if (request.workoutCompleted() != null && request.workoutCompleted() < 0) {
+            throw new IllegalArgumentException("Workout count cannot be negative");
+        }
+
+        UserProfile userProfile = userProfileRepository
+                .findByUserId(userId)
+                .orElseThrow(() -> new ProfileNotFoundException("Profile not found"));
+
+        ProgressEntry entry = progressEntryMapper.toEntity(request);
+
+        entry.setRecordedAt(Instant.now());
+        entry.setUserProfile(userProfile);
+
+        progressEntryRepository.save(entry);
+
+        return progressEntryMapper.toResponse(entry);
+    }
+
+    public List<ProgressEntryResponse> getAll(UUID userId) {
+
+        return progressEntryRepository
+                .findByUserProfile_UserId(userId)
+                .stream()
+                .map(progressEntryMapper::toResponse)
+                .toList();
+    }
+
+//    public void delete(UUID userId, UUID id) {
+//
+//        ProgressEntry entry = progressEntryRepository.findById(entryId)
+//                .orElseThrow(() -> new ProgressEntryFoundException("Progress entry not found"));
+//
+//        if (!entry.getUserProfile().getUserId().equals(userId)) {
+//            throw new UnauthorizedException("You cannot delete this entry");
+//        }
+//
+//        progressEntryRepository.delete(entry);
+//    }
+}

--- a/src/main/java/com/wellu/usermanagement/service/ProgressEntryService.java
+++ b/src/main/java/com/wellu/usermanagement/service/ProgressEntryService.java
@@ -1,10 +1,13 @@
 package com.wellu.usermanagement.service;
 
 import com.wellu.usermanagement.dto.request.ProgressEntryCreateRequest;
+import com.wellu.usermanagement.dto.request.ProgressEntryUpdateRequest;
 import com.wellu.usermanagement.dto.response.ProgressEntryResponse;
 import com.wellu.usermanagement.entity.ProgressEntry;
 import com.wellu.usermanagement.entity.UserProfile;
+import com.wellu.usermanagement.exception.AuthenticationException;
 import com.wellu.usermanagement.exception.ProfileNotFoundException;
+import com.wellu.usermanagement.exception.ProgressEntryException;
 import com.wellu.usermanagement.mapper.ProgressEntryMapper;
 import com.wellu.usermanagement.repository.ProgressEntryRepository;
 import com.wellu.usermanagement.repository.UserProfileRepository;
@@ -27,17 +30,8 @@ public class ProgressEntryService {
     }
 
     public ProgressEntryResponse create(UUID userId, ProgressEntryCreateRequest request) {
-        if (request.weight() == null || request.weight() <= 0) {
-            throw new IllegalArgumentException("Weight must be greater than 0");
-        }
 
-        if (request.caloriesBurnt() != null && request.caloriesBurnt() < 0) {
-            throw new IllegalArgumentException("Calories burnt cannot be negative");
-        }
-
-        if (request.workoutCompleted() != null && request.workoutCompleted() < 0) {
-            throw new IllegalArgumentException("Workout count cannot be negative");
-        }
+        progressEntryCreateValidation(request);
 
         UserProfile userProfile = userProfileRepository
                 .findByUserId(userId)
@@ -53,6 +47,8 @@ public class ProgressEntryService {
         return progressEntryMapper.toResponse(entry);
     }
 
+
+
     public List<ProgressEntryResponse> getAll(UUID userId) {
 
         return progressEntryRepository
@@ -62,15 +58,59 @@ public class ProgressEntryService {
                 .toList();
     }
 
-//    public void delete(UUID userId, UUID id) {
-//
-//        ProgressEntry entry = progressEntryRepository.findById(entryId)
-//                .orElseThrow(() -> new ProgressEntryFoundException("Progress entry not found"));
-//
-//        if (!entry.getUserProfile().getUserId().equals(userId)) {
-//            throw new UnauthorizedException("You cannot delete this entry");
-//        }
-//
-//        progressEntryRepository.delete(entry);
-//    }
+    public void delete(UUID userId, UUID id) {
+
+        ProgressEntry entry = progressEntryRepository.findById(id)
+                .orElseThrow(() -> new ProgressEntryException("Progress entry not found"));
+
+        if (!entry.getUserProfile().getUser().getId().equals(userId)) {
+            throw new AuthenticationException("You cannot delete this entry");
+        }
+
+        progressEntryRepository.delete(entry);
+    }
+
+    public ProgressEntryResponse update(UUID userId, UUID id, ProgressEntryUpdateRequest request) {
+        ProgressEntry entry = progressEntryRepository.findById(id)
+                .orElseThrow(() -> new ProgressEntryException("Progress entry not found"));
+
+        if (!entry.getUserProfile().getUser().getId().equals(userId)) {
+            throw new AuthenticationException("You cannot delete this entry");
+        }
+
+        progressEntryUpdateValidation(request);
+        progressEntryMapper.updateFromDto(request, entry);
+        progressEntryRepository.save(entry);
+
+        return progressEntryMapper.toResponse(entry);
+    }
+
+    private void progressEntryCreateValidation(ProgressEntryCreateRequest request) {
+        if (request.weight() == null || request.weight() <= 0) {
+            throw new ProgressEntryException("Weight must be greater than 0");
+        }
+
+        if (request.caloriesBurnt() != null && request.caloriesBurnt() < 0) {
+            throw new ProgressEntryException("Calories burnt cannot be negative");
+        }
+
+        if (request.workoutCompleted() != null && request.workoutCompleted() < 0) {
+            throw new ProgressEntryException("Workout count cannot be negative");
+        }
+    }
+
+    private void progressEntryUpdateValidation(ProgressEntryUpdateRequest request) {
+
+        if (request.weight() != null && request.weight() <= 0) {
+            throw new ProgressEntryException("Weight must be greater than 0");
+        }
+
+        if (request.caloriesBurnt() != null && request.caloriesBurnt() < 0) {
+            throw new ProgressEntryException("Calories burnt cannot be negative");
+        }
+
+        if (request.workoutCompleted() != null && request.workoutCompleted() < 0) {
+            throw new ProgressEntryException("Workout count cannot be negative");
+        }
+    }
 }


### PR DESCRIPTION
## 📝 Description

This PR adds update support for **ProgressEntry** and improves validation and mapping logic.

## ✅ Changes

- Added `PUT /progress-entries/{id}` endpoint
- Introduced `ProgressEntryUpdateRequest` DTO
- Implemented partial update using MapStruct with `NullValuePropertyMappingStrategy.IGNORE`
- Added ownership validation using authenticated user (`@AuthenticationPrincipal`)
- Refactored validation logic for update flow
- Secured update and delete operations to ensure entries belong to the authenticated user

## 🔒 Security

- Removed reliance on client-provided `userId`
- Ownership is now verified through the authenticated principal

## 📌 Available Endpoints

- `POST /progress-entries`
- `GET /progress-entries`
- `PUT /progress-entries/{id}`
- `DELETE /progress-entries/{id}`
closes #19 